### PR TITLE
Fix `Evaluator.getscore()` so it returns top1 and mrr scores

### DIFF
--- a/insurance_qa_eval.py
+++ b/insurance_qa_eval.py
@@ -159,6 +159,8 @@ class Evaluator:
         return self._eval_sets
 
     def get_score(self, verbose=False):
+        top1_ls = []
+        mrr_ls = []
         for name, data in self.eval_sets().items():
             print('----- %s -----' % name)
 
@@ -204,6 +206,9 @@ class Evaluator:
             del data
             print('Top-1 Precision: %f' % top1)
             print('MRR: %f' % mrr)
+            top1_ls.append(top1)
+            mrr_ls.append(mrr)
+        return top1_ls, mrr_ls
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This fixes the `TypeError: 'NoneType' object is not iterable` that
is thrown when running `insurance_qa_eval.py`. This commit fixes
issue #29 